### PR TITLE
Fix typo in generated alert message

### DIFF
--- a/bin/discord_alert_action.py
+++ b/bin/discord_alert_action.py
@@ -36,7 +36,7 @@ def main():
 
     if result_link == "0":
         fields = [
-            {"name": "Severty", "value": severity, "inline": False},
+            {"name": "Severity", "value": severity, "inline": False},
             {
                 "name": "Alert Owner",
                 "value": str(payload.get("owner")),


### PR DESCRIPTION
The current alert message has a typo in the 'Severity' header each time an alert fires. Added the fix here as a PR for convenience.